### PR TITLE
Enable utf-8 output for clean redirection

### DIFF
--- a/chronologicon/output.py
+++ b/chronologicon/output.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 # Chronologicon v4.x
 # Rutherford Craze
@@ -173,13 +174,13 @@ def ViewStats(args):
 	print(AvgEntry)
 
 	print('\n  Work by discipline\n')
-	print(dbtGraph)
+	print(dbtGraph.encode('utf-8'))
 	print(dbtKey)
 
 	print('\n\n  Work by hour')
-	print(wbhGraph)
+	print(wbhGraph.encode('utf-8'))
 	print('  | ' + (BAR_WIDTH - 2) * '─')
 	print(wbhKey)
 
 	print('\n\n  Largest projects\n')
-	print(pbtList)
+	print(pbtList.encode('utf-8'))


### PR DESCRIPTION
Python was throwing an error when I tried to pipe the output to a file or to other terminal programs.
This change allows this app to be used with other terminal apps.

To test, try:
`paste <(curl wttr.in/?T 2> /dev/null) <(chron -v) | column -s $'\t' -t`